### PR TITLE
feat: purchase balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Essa aplicação executa através do `shell` disponivel no seu sistema operacion
  Ticker      ITSA3                                   
  Name        ITAUSA                                  
  Document    61.532.644/0001-15                      
- Currency    BRL R$                                  
+ Currency    R$ BRL                                  
  Price       10.87                                   
- CapturedAt  2025-06-08 20:04:59                     
+ CapturedAt  2025-06-08 22:59:37                     
  Origin      https://statusinvest.com.br/acoes/itsa3 
 ```
 
@@ -43,15 +43,15 @@ Essa aplicação executa através do `shell` disponivel no seu sistema operacion
 ./trader stock list ITSA3 BBDC3 VALE3 ABEV3 PETR4 WEGE3 IGTA3 B3SA3
 
 # Output:
- TICKER  NAME                                  DOCUMENT            CURRENCY  PRICE  CAPTURED AT         
- ITSA3   ITAUSA                                61.532.644/0001-15  BRL R$    10.87  2025-06-08 20:05:19 
- BBDC3   BRADESCO                              60.746.948/0001-12  BRL R$    13.75  2025-06-08 20:05:19 
- VALE3   VALE                                  33.592.510/0001-54  BRL R$    52.90  2025-06-08 20:05:19 
- ABEV3   AMBEV                                 07.526.557/0001-00  BRL R$    14.05  2025-06-08 20:05:19 
- PETR4   PETROBRAS                             33.000.167/0001-01  BRL R$    29.59  2025-06-08 20:05:20 
- WEGE3   WEG                                   84.429.695/0001-11  BRL R$    42.57  2025-06-08 20:05:20 
- IGTA3   IGUATEMI EMPRESA DE SHOPPING CENTERS  51.218.147/0001-93  BRL R$    33.00  2025-06-08 20:05:20 
- B3SA3   B3                                    09.346.601/0001-25  BRL R$    13.55  2025-06-08 20:05:20 
+ TICKER  NAME                                  DOCUMENT            PRICE  CURRENCY  CAPTURED AT         
+  ITSA3  ITAUSA                                61.532.644/0001-15  10.87  R$ BRL    2025-06-08 23:03:44 
+  BBDC3  BRADESCO                              60.746.948/0001-12  13.75  R$ BRL    2025-06-08 23:03:44 
+  VALE3  VALE                                  33.592.510/0001-54  52.90  R$ BRL    2025-06-08 23:03:45 
+  ABEV3  AMBEV                                 07.526.557/0001-00  14.05  R$ BRL    2025-06-08 23:03:45 
+  PETR4  PETROBRAS                             33.000.167/0001-01  29.59  R$ BRL    2025-06-08 23:03:45 
+  WEGE3  WEG                                   84.429.695/0001-11  42.57  R$ BRL    2025-06-08 23:03:45 
+  IGTA3  IGUATEMI EMPRESA DE SHOPPING CENTERS  51.218.147/0001-93  33.00  R$ BRL    2025-06-08 23:03:46 
+  B3SA3  B3                                    09.346.601/0001-25  13.55  R$ BRL    2025-06-08 23:03:46 
 ```
 
 3. Execute a aplicação para obter o preço do FII pelo ticker:
@@ -69,10 +69,10 @@ Essa aplicação executa através do `shell` disponivel no seu sistema operacion
  Admin       BTG PACTUAL SERVIÇOS FINANCEIROS S/A DTVM              
  Document    97.521.225/0001-25                                     
  Segment     Híbrido                                                
- Currency    BRL R$                                                 
+ Currency    R$ BRL                                                 
  Price       9.41                                                   
- CapturedAt  2025-06-08 20:04:04                                    
- Origin      https://statusinvest.com.br/fundos-imobiliarios/mxrf11    
+ CapturedAt  2025-06-08 23:02:13                                    
+ Origin      https://statusinvest.com.br/fundos-imobiliarios/mxrf11 
 ```
 
 4. Execute a aplicação para listar o preços dos FIIs:
@@ -84,10 +84,78 @@ Essa aplicação executa através do `shell` disponivel no seu sistema operacion
 ./trader reit list MXRF11 XPML11 GARE11 HGLG11 VGHF11
 
 # Output:
- TICKER  NAME                  DOCUMENT            CURRENCY   PRICE  CAPTURED AT         
- MXRF11  Maxi Renda            97.521.225/0001-25  BRL R$      9.41  2025-06-08 20:04:25 
- XPML11  XP Malls              28.757.546/0001-00  BRL R$    103.21  2025-06-08 20:04:25 
- GARE11  Guardian Real Estate  37.295.919/0001-60  BRL R$      8.73  2025-06-08 20:04:25 
- HGLG11  CGHG Logística        11.728.688/0001-47  BRL R$    156.20  2025-06-08 20:04:25 
- VGHF11  VALORA HEDGE FUND     36.771.692/0001-19  BRL R$      7.70  2025-06-08 20:04:26 
+ TICKER  NAME                  DOCUMENT             PRICE  CURRENCY  CAPTURED AT         
+ MXRF11  Maxi Renda            97.521.225/0001-25    9.41  R$ BRL    2025-06-08 23:02:37 
+ XPML11  XP Malls              28.757.546/0001-00  103.21  R$ BRL    2025-06-08 23:02:37 
+ GARE11  Guardian Real Estate  37.295.919/0001-60    8.73  R$ BRL    2025-06-08 23:02:38 
+ HGLG11  CGHG Logística        11.728.688/0001-47  156.20  R$ BRL    2025-06-08 23:02:38 
+ VGHF11  VALORA HEDGE FUND     36.771.692/0001-19    7.70  R$ BRL    2025-06-08 23:02:38 
+```
+
+5. Balancear portifolio de ações:
+
+```sh
+# Windows
+.\trader.exe stock purchase-balance ITSA3 BBDC3 VALE3 ABEV3 PETR4 WEGE3 IGTA3 B3SA3 --amount 1000
+# Linux/Mac
+./trader stock purchase-balance ITSA3 BBDC3 VALE3 ABEV3 PETR4 WEGE3 IGTA3 B3SA3 --amount 1000
+
+# Output:
+ TICKER  PRICE  COUNT   TOTAL  CURRENCY  CAPTURED AT         
+  ITSA3  10.87     12  130.44  R$ BRL    2025-06-08 23:13:46 
+  BBDC3  13.75     10  137.50  R$ BRL    2025-06-08 23:13:46 
+  VALE3  52.90      3  158.70  R$ BRL    2025-06-08 23:13:46 
+  ABEV3  14.05      9  126.45  R$ BRL    2025-06-08 23:13:46 
+  PETR4  29.59      4  118.36  R$ BRL    2025-06-08 23:13:47 
+  WEGE3  42.57      2   85.14  R$ BRL    2025-06-08 23:13:47 
+  IGTA3  33.00      3   99.00  R$ BRL    2025-06-08 23:13:47 
+  B3SA3  13.55     10  135.50  R$ BRL    2025-06-08 23:13:47 
+                   53  991.09  R$ BRL    SPENT AMOUNT        
+                         8.91  R$ BRL    REMAINING AMOUNT                                                                          
+```
+
+6. Balancear portifolio de FIIs:
+
+```sh
+# Windows
+.\trader.exe reit purchase-balance MXRF11 XPML11 GARE11 HGLG11 VGHF11 --amount 1000
+# Linux/Mac
+./trader reit purchase-balance MXRF11 XPML11 GARE11 HGLG11 VGHF11 --amount 1000
+
+# Output:
+ TICKER   PRICE  COUNT   TOTAL  CURRENCY  CAPTURED AT         
+ MXRF11    9.41     23  216.43  R$ BRL    2025-06-08 23:14:08 
+ XPML11  103.21      2  206.42  R$ BRL    2025-06-08 23:14:08 
+ GARE11    8.73     24  209.52  R$ BRL    2025-06-08 23:14:08 
+ HGLG11  156.20      1  156.20  R$ BRL    2025-06-08 23:14:09 
+ VGHF11    7.70     27  207.90  R$ BRL    2025-06-08 23:14:09 
+                    77  996.47  R$ BRL    SPENT AMOUNT        
+                          3.53  R$ BRL    REMAINING AMOUNT    
+```
+
+7. Balancear portifolio entre ações e FIIs:
+
+```sh
+# Windows
+.\trader.exe security purchase-balance --stocks ITSA3,BBDC3,VALE3,ABEV3,PETR4,WEGE3,IGTA3,B3SA3 --reits MXRF11,XPML11,GARE11,HGLG11,VGHF11 --amount 1000
+# Linux/Mac
+./trader security purchase-balance --stocks ITSA3,BBDC3,VALE3,ABEV3,PETR4,WEGE3,IGTA3,B3SA3 --reits MXRF11,XPML11,GARE11,HGLG11,VGHF11 --amount 1000
+
+# Output:
+ TICKER  TYPE    PRICE  COUNT   TOTAL  CURRENCY  CAPTURED AT         
+  ITSA3  Stock   10.87      9   97.83  R$ BRL    2025-06-08 23:14:44 
+  BBDC3  Stock   13.75      7   96.25  R$ BRL    2025-06-08 23:14:45 
+  VALE3  Stock   52.90      2  105.80  R$ BRL    2025-06-08 23:14:45 
+  ABEV3  Stock   14.05      7   98.35  R$ BRL    2025-06-08 23:14:46 
+  PETR4  Stock   29.59      3   88.77  R$ BRL    2025-06-08 23:14:46 
+  WEGE3  Stock   42.57      2   85.14  R$ BRL    2025-06-08 23:14:47 
+  IGTA3  Stock   33.00      3   99.00  R$ BRL    2025-06-08 23:14:47 
+  B3SA3  Stock   13.55      6   81.30  R$ BRL    2025-06-08 23:14:48 
+ MXRF11  REIT     9.41      9   84.69  R$ BRL    2025-06-08 23:14:48 
+ XPML11  REIT   103.21      0    0.00  R$ BRL    2025-06-08 23:14:48 
+ GARE11  REIT     8.73      9   78.57  R$ BRL    2025-06-08 23:14:49 
+ HGLG11  REIT   156.20      0    0.00  R$ BRL    2025-06-08 23:14:49 
+ VGHF11  REIT     7.70     10   77.00  R$ BRL    2025-06-08 23:14:49 
+                           67  992.70  R$ BRL    SPENT AMOUNT        
+                                 7.30  R$ BRL    REMAINING AMOUNT    
 ```

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,7 @@
+package cmd
+
+var (
+	flagAmount float64
+	flagStocks string
+	flagReits  string
+)

--- a/cmd/security.go
+++ b/cmd/security.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"trader/internal/common"
+	"trader/internal/service"
+	"trader/internal/tools"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+var securityCmd = &cobra.Command{
+	Use:   "security",
+	Short: "Tool to get security information",
+	Long:  `Tool to get security information`,
+}
+
+var securityPurchaseBalanceByTickersCmd = &cobra.Command{
+	Use:   "purchase-balance --stocks [tickers ...] --reits [tickers ...] --amount <float>",
+	Short: "Purchase balance by tickers",
+	Long:  `Purchase balance by tickers`,
+	Run: func(cmd *cobra.Command, args []string) {
+		stocks := strings.Split(flagStocks, ",")
+		reits := strings.Split(flagReits, ",")
+		purchaseBalance := service.MakeSecuritiesPurchaseBalance(stocks, reits, flagAmount)
+		if len(purchaseBalance.SecuritiesBalance) == 0 {
+			fmt.Println("Error: tickers not found!")
+			return
+		}
+		t := common.NewTableWriter()
+		t.AppendHeader(table.Row{"TICKER", "TYPE", "PRICE", "COUNT", "TOTAL", "CURRENCY", "CAPTURED AT"})
+		currency := purchaseBalance.SecuritiesBalance[0].Security.Currency.String()
+		for _, purchase := range purchaseBalance.SecuritiesBalance {
+			t.AppendRow(table.Row{purchase.Security.Ticker, purchase.Security.Type, tools.TableRowValue(purchase.Security.Price), purchase.Count, tools.TableRowValue(purchase.TotalAmount()), currency, tools.TableRowValue(purchase.Security.CapturedAt)})
+		}
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{
+				Name:        "TICKER",
+				Align:       text.AlignRight,
+				AlignHeader: text.AlignRight,
+				AlignFooter: text.AlignRight,
+			},
+			{
+				Name:        "PRICE",
+				Align:       text.AlignRight,
+				AlignHeader: text.AlignRight,
+				AlignFooter: text.AlignRight,
+			},
+			{
+				Name:        "TOTAL",
+				Align:       text.AlignRight,
+				AlignHeader: text.AlignRight,
+				AlignFooter: text.AlignRight,
+			},
+		})
+		t.AppendFooter(table.Row{"", "", "", purchaseBalance.TotalCount(), tools.TableRowValue(purchaseBalance.AmountSpent()), currency, "SPENT AMOUNT"})
+		t.AppendFooter(table.Row{"", "", "", "", tools.TableRowValue(purchaseBalance.RemainingBalance()), currency, "REMAINING AMOUNT"})
+		t.SetIndexColumn(1)
+		t.Render()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(securityCmd)
+	securityCmd.AddCommand(securityPurchaseBalanceByTickersCmd)
+
+	securityPurchaseBalanceByTickersCmd.Flags().StringVarP(&flagStocks, "stocks", "s", "", "List of stocks to purchase [ticker1,ticker2...] (required)")
+	securityPurchaseBalanceByTickersCmd.Flags().StringVarP(&flagReits, "reits", "r", "", "List of REITs to purchase [ticker1,ticker2...] (required)")
+	securityPurchaseBalanceByTickersCmd.Flags().Float64VarP(&flagAmount, "amount", "a", 0.0, "Amount invested (required)")
+	securityPurchaseBalanceByTickersCmd.MarkFlagsRequiredTogether("amount")
+}

--- a/internal/common/table.go
+++ b/internal/common/table.go
@@ -8,7 +8,7 @@ import (
 
 func NewTableWriter() table.Writer {
 	style := table.StyleColoredBlackOnBlueWhite
-	style.Options = table.OptionsNoBordersAndSeparators
+	// style.Options = table.OptionsNoBordersAndSeparators
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetStyle(style)

--- a/internal/resource/currency.go
+++ b/internal/resource/currency.go
@@ -1,7 +1,13 @@
 package resource
 
+import "fmt"
+
 type Currency struct {
 	Code        string `json:"code"`
 	Sign        string `json:"sign"`
 	Description string `json:"description"`
+}
+
+func (c *Currency) String() string {
+	return fmt.Sprintf("%s %s", c.Sign, c.Code)
 }

--- a/internal/resource/purchase.go
+++ b/internal/resource/purchase.go
@@ -1,0 +1,35 @@
+package resource
+
+type SecurityPurchase struct {
+	Security *Security `json:"security"`
+	Count    int       `json:"count"`
+}
+
+func (sb *SecurityPurchase) TotalAmount() float64 {
+	return sb.Security.Price * float64(sb.Count)
+}
+
+type PurchaseBalance struct {
+	SecuritiesBalance []*SecurityPurchase `json:"securitiesBalance"`
+	AmountInvested    float64             `json:"amountInvested"`
+}
+
+func (pb *PurchaseBalance) TotalCount() int {
+	var total int = 0
+	for _, sb := range pb.SecuritiesBalance {
+		total += sb.Count
+	}
+	return total
+}
+
+func (pb *PurchaseBalance) AmountSpent() float64 {
+	var total float64 = 0.0
+	for _, sb := range pb.SecuritiesBalance {
+		total += sb.TotalAmount()
+	}
+	return total
+}
+
+func (pb *PurchaseBalance) RemainingBalance() float64 {
+	return pb.AmountInvested - pb.AmountSpent()
+}

--- a/internal/resource/security.go
+++ b/internal/resource/security.go
@@ -3,7 +3,7 @@ package resource
 import "time"
 
 const (
-	STOCK_TYPE string = "STOCK"
+	STOCK_TYPE string = "Stock"
 	REIT_TYPE  string = "REIT"
 )
 

--- a/internal/service/reit.go
+++ b/internal/service/reit.go
@@ -14,5 +14,12 @@ func GetReit(ticker string) *resource.Security {
 }
 
 func ListReits(tickers []string) []*resource.Security {
-	return scraping.ListReitsByTickers(tickers)
+	result := scraping.ListReitsByTickers(tickers)
+	return result
+}
+
+func MakeReitPurchaseBalance(tickers []string, amountInvested float64) *resource.PurchaseBalance {
+	reits := ListReits(tickers)
+	result := MakePurchaseBalance(reits, amountInvested)
+	return result
 }

--- a/internal/service/security.go
+++ b/internal/service/security.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"math"
+	"trader/internal/resource"
+)
+
+func MakePurchaseBalance(securities []*resource.Security, amountInvested float64) *resource.PurchaseBalance {
+	stockCount := len(securities)
+	stockValue := amountInvested / float64(stockCount)
+	remainingBalance := amountInvested
+	priceMin := math.MaxFloat64
+	securitiesPurchase := make([]*resource.SecurityPurchase, 0)
+	for _, stock := range securities {
+		if stock.Price < priceMin {
+			priceMin = stock.Price
+		}
+		securityPurchase := &resource.SecurityPurchase{
+			Security: stock,
+			Count:    int(stockValue / stock.Price),
+		}
+		securitiesPurchase = append(securitiesPurchase, securityPurchase)
+		remainingBalance = remainingBalance - securityPurchase.TotalAmount()
+	}
+	for {
+		if remainingBalance >= priceMin {
+			for i := range stockCount {
+				if remainingBalance >= securitiesPurchase[i].Security.Price {
+					securitiesPurchase[i].Count += 1
+					remainingBalance = remainingBalance - securitiesPurchase[i].Security.Price
+				}
+			}
+		} else {
+			break
+		}
+	}
+	return &resource.PurchaseBalance{SecuritiesBalance: securitiesPurchase, AmountInvested: amountInvested}
+}
+
+func MakeSecuritiesPurchaseBalance(stockTickers []string, reitTickers []string, amountInvested float64) *resource.PurchaseBalance {
+	stocks := ListStocks(stockTickers)
+	reits := ListReits(reitTickers)
+	securities := append(stocks, reits...)
+	result := MakePurchaseBalance(securities, amountInvested)
+	return result
+}

--- a/internal/service/stock.go
+++ b/internal/service/stock.go
@@ -14,5 +14,12 @@ func GetStock(ticker string) *resource.Security {
 }
 
 func ListStocks(tickers []string) []*resource.Security {
-	return scraping.ListStocksByTickers(tickers)
+	result := scraping.ListStocksByTickers(tickers)
+	return result
+}
+
+func MakeStockPurchaseBalance(tickers []string, amountInvested float64) *resource.PurchaseBalance {
+	stocks := ListStocks(tickers)
+	result := MakePurchaseBalance(stocks, amountInvested)
+	return result
 }


### PR DESCRIPTION
Foi desenvolvido um balanceador de portfólio.
Exemplo:
```sh
# Windows
.\trader.exe security purchase-balance --stocks ITSA3,BBDC3,VALE3,ABEV3,PETR4,WEGE3,IGTA3,B3SA3 --reits MXRF11,XPML11,GARE11,HGLG11,VGHF11 --amount 1000
# Linux/Mac
./trader security purchase-balance --stocks ITSA3,BBDC3,VALE3,ABEV3,PETR4,WEGE3,IGTA3,B3SA3 --reits MXRF11,XPML11,GARE11,HGLG11,VGHF11 --amount 1000

# Output:
 TICKER  TYPE    PRICE  COUNT   TOTAL  CURRENCY  CAPTURED AT         
  ITSA3  Stock   10.87      9   97.83  R$ BRL    2025-06-08 23:14:44 
  BBDC3  Stock   13.75      7   96.25  R$ BRL    2025-06-08 23:14:45 
  VALE3  Stock   52.90      2  105.80  R$ BRL    2025-06-08 23:14:45 
  ABEV3  Stock   14.05      7   98.35  R$ BRL    2025-06-08 23:14:46 
  PETR4  Stock   29.59      3   88.77  R$ BRL    2025-06-08 23:14:46 
  WEGE3  Stock   42.57      2   85.14  R$ BRL    2025-06-08 23:14:47 
  IGTA3  Stock   33.00      3   99.00  R$ BRL    2025-06-08 23:14:47 
  B3SA3  Stock   13.55      6   81.30  R$ BRL    2025-06-08 23:14:48 
 MXRF11  REIT     9.41      9   84.69  R$ BRL    2025-06-08 23:14:48 
 XPML11  REIT   103.21      0    0.00  R$ BRL    2025-06-08 23:14:48 
 GARE11  REIT     8.73      9   78.57  R$ BRL    2025-06-08 23:14:49 
 HGLG11  REIT   156.20      0    0.00  R$ BRL    2025-06-08 23:14:49 
 VGHF11  REIT     7.70     10   77.00  R$ BRL    2025-06-08 23:14:49 
                           67  992.70  R$ BRL    SPENT AMOUNT        
                                 7.30  R$ BRL    REMAINING AMOUNT    
```